### PR TITLE
[docs] 修改commit格式規範, 修改開發前例行步驟

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git push origin feature/your-name-task
 
    ```bash
    git pull origin dev
-   git merge dev
+   git push origin feature/your-name-task
    # 解完 conflict 再 push，然後開 PR
    ```
 ### 命名規範
@@ -110,7 +110,7 @@ git push origin feature/your-name-task
 | Pinia Store 命名        | snake_case (小寫蛇式命名)        | `defineStore('user_store', { ... })`                           |
 | API 路由命名            | 小寫 + 複數名詞                  | `GET /api/users``POST /api/projects``DELETE /api/messages/:id` |
 | Git 分支命名            | 使用結構：`type/feature-name`    | `feat/login-page` `fix/api-timeout` `refactor/editor-toolbar`  `issue/20`  |
-| Commit 訊息命名    |  參考 Conventional Commit 規範，格式：`<type>: <描述>`    | `feat: 新增註冊功能` `fix: 修正登入 API 回傳錯誤` `docs: 補上 README 命名規範`    |
+| Commit 訊息命名    |  參考 Conventional Commit 規範，格式：`[type]description`    | `feat: 新增註冊功能` `fix: 修正登入 API 回傳錯誤` `docs: 補上 README 命名規範`    |
 
 
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ git push origin feature/your-name-task
 | Pinia Store 命名        | snake_case (小寫蛇式命名)        | `defineStore('user_store', { ... })`                           |
 | API 路由命名            | 小寫 + 複數名詞                  | `GET /api/users``POST /api/projects``DELETE /api/messages/:id` |
 | Git 分支命名            | 使用結構：`type/feature-name`    | `feat/login-page` `fix/api-timeout` `refactor/editor-toolbar`  `issue/20`  |
-| Commit 訊息命名    |  參考 Conventional Commit 規範，格式：`[type]description`    | `feat: 新增註冊功能` `fix: 修正登入 API 回傳錯誤` `docs: 補上 README 命名規範`    |
+| Commit 訊息命名    |  參考 Conventional Commit 規範，格式：`[type]description`    | `[feat] 新增註冊功能` `[fix] 修正登入 API 回傳錯誤` `[docs] 補上 README 命名規範`    |
 
 
 


### PR DESCRIPTION
1. 修改開發前例行步驟第二點
    git merge dev 是將本地dev分支合併至目前所在分支
    如果你原本所在位置是在自己的開發分支，例如 feature/home-page
    則執行 git pull origin dev 會把遠端 dev 分支合併到你現在的 feature/home-page 分支上 (該在此時解衝突)
    但本地的 dev 分支並沒有更新進度
    此時執行 git merge dev 會再把本地的 dev 分支合併到 feature/home-page 上，可能會有意想不到的問題，所以這條指令是多餘的
![image](https://github.com/user-attachments/assets/dc34a697-b6a8-4024-b77b-7572ccb25776)

2. 修改 Commit 訊息命名規範
   從 type: description 改為 [type]description
   
![image](https://github.com/user-attachments/assets/d267de5d-7e23-4b69-8b78-fdec55be141c)
