### PR TITLE
[feat] 新增Editor Footer 以及 controller for Console

### DIFF
--- a/client/src/components/Editor/EditorSmallButton.vue
+++ b/client/src/components/Editor/EditorSmallButton.vue
@@ -1,0 +1,9 @@
+<template>
+  <button type="button" class="bg-[#43454f] py-[3px] px-[7px] text-[12px] leading-4 rounded-xs" @click="$emit('buttonClick')">
+    <slot></slot>
+  </button>
+</template>
+
+<script setup>
+  defineEmits(['buttonClick'])
+</script>

--- a/client/src/views/Pen.vue
+++ b/client/src/views/Pen.vue
@@ -9,7 +9,14 @@
   import Layout from '../assets/layout.svg';
   import Bookmark from '../assets/bookmark.svg';
 
+  import EditorSmallButton from '../components/Editor/EditorSmallButton.vue'
+
 	const isLoggedIn = ref(true)
+  const isConsoleShow = ref(true)
+
+  const handleConsoleShow = ()=> {
+    isConsoleShow.value = !isConsoleShow.value
+  }
 </script>
 <template>
   <nav class="relative h-[65px] w-full bg-black flex items-center justify-between">
@@ -85,4 +92,13 @@
       </div>
     </div>
   </nav>
+
+  <footer class="h-8 w-full flex relative justify-between items-center py-[.2rem] px-2 bg-[#2C303A] text-white">
+      <div class="flex items-center h-full">
+        <EditorSmallButton class="hover:bg-[#5a5f73]" @buttonClick="handleConsoleShow">Console</EditorSmallButton>
+      </div>
+      <div class="flex items-center h-full">
+        <EditorSmallButton class="hover:bg-[#ff3c41]">Delete</EditorSmallButton>
+      </div>
+  </footer>
 </template>


### PR DESCRIPTION
 新增Editor Footer 以及 controller for Console。
Pen這一頁會用Header / Editor / Preview / Footer撐開填滿全頁 所以在沒有Editor / Preview的狀況下Header  / Footer會黏再一起
![截圖 2025-05-16 23 20 19](https://github.com/user-attachments/assets/6c2c3c2d-56ff-4f5d-9535-e6a82b60b7d4)

#32 