### PR TITLE
[feat] 新增主頁面footer

### DIFF
--- a/client/src/components/SubFooter.vue
+++ b/client/src/components/SubFooter.vue
@@ -1,9 +1,57 @@
 <template>
-	<div>FOOTER</div>
+
+  <footer class="bg-[#0d0d0d] text-white text-xs px-20 py-10 flex flex-wrap justify-between">
+    <nav aria-label="Links about CodePen">
+      <h4 class="font-bold mb-2">Codecaine</h4>
+      <ul class="space-y-1">
+        <li><a href="/about">About</a></li>
+        <li><a href="/blog">Blog</a></li>
+        <li><a href="https://blog.codepen.io/radio/" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+        <li><a href="https://blog.codepen.io/documentation/" target="_blank" rel="noopener noreferrer">Documentation</a></li>
+        <li><a href="/support">Support</a></li>
+        <li><a href="/advertise">Advertise</a></li>
+      </ul>
+    </nav>
+
+    <nav aria-label="CodePen for different uses">
+      <h4 class="font-bold mb-2">The third group's github</h4>
+      <ul class="space-y-1">
+        <li><a href="">Hoppy</a></li>
+        <li><a href="">Vivi Sun</a></li>
+        <li><a href="">barry</a></li>
+        <li><a href="">kaia</a></li>
+        <li><a href="">威廷</a></li>
+        <li><a href="">Primitive</a></li>
+        <li><a href="">郁婷</a></li>
+      </ul>
+    </nav>
+
+    <nav aria-label="CodePen on Social Media">
+      <h4 class="font-bold mb-2">Social</h4>
+      <ul class="space-y-1">
+        <li><a href="" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="" target="_blank" rel="noopener noreferrer"></a></li>
+        <li><a href="" target="_blank" rel="noopener noreferrer"></a></li>
+        <li><a href="" target="_blank" rel="me noopener noreferrer"></a></li>
+      </ul>
+    </nav>
+
+    <nav aria-label="Codecaine Community">
+      <h4 class="font-bold mb-2">Community</h4>
+      <ul class="space-y-1">
+        <li><a href="/spark/">Spark</a></li>
+        <li><a href="/challenges/">Challenges</a></li>
+        <li><a href="/topics/">Topics</a></li>
+        <li><a href="https://blog.codepen.io/documentation/code-conduct/" target="_blank" rel="noopener noreferrer">Code of Conduct</a></li>
+      </ul>
+    </nav>
+
+    <div class="w-full text-center mt-10 text-[11px] text-gray-500">
+      <p>©2025 Codecaine</p>
+    </div>
+  </footer>
 </template>
 
-<style scoped>
-div {
-	background-color: green;
-}
-</style>
+<script setup>
+// 無需引入其他元件
+</script>

--- a/client/src/layouts/MainLayout.vue
+++ b/client/src/layouts/MainLayout.vue
@@ -35,8 +35,8 @@ function toggleSidebar() {
 		"sidebar header"
 		"sidebar content"
 		"sidebar footer";
-	grid-template-rows: 75px 1fr 75px; /* 先寫死表示大概畫面 再自行修正*/
-	height: 100vh;
+	grid-template-rows: 75px 1fr auto; /* 先寫死表示大概畫面 再自行修正*/
+	/* height: 100vh; */
 }
 
 .sidebar {
@@ -49,6 +49,8 @@ function toggleSidebar() {
 
 .content {
 	grid-area: content;
+	overflow-y: auto;
+	min-height: calc(100vh - 75px); /* 75px -> .layout 裡寫死grid裡的第一行row的高度 Kaia把 header 上船之後請把這裡改掉*/
 }
 
 .footer {


### PR DESCRIPTION
close #8 
新增主頁面Footer (哈比的專案資料夾有問題，為了避免無法預期的情況，先把他的code用我的電腦推)
元件位置：
畫面效果：
1.
![image](https://github.com/user-attachments/assets/d49b9261-01d6-4f90-bbe4-c31070973663)
2.
![image](https://github.com/user-attachments/assets/6373a574-d7b5-4a7a-9695-6831f4713885)

修改MainLayout.vue
![image](https://github.com/user-attachments/assets/c452992b-f1bc-45f4-a20d-96c48ef3998f)

`grid-template-rows: 75px 1fr 75px;` 改為 `grid-template-rows: 75px 1fr auto;` 以讓最下方row 隨 footer 內容自動撐開，且取消寫死的 `height: 100vh;`

而`.content`高度改為以下寫法，以達到與CodePen類似的版面效果
![image](https://github.com/user-attachments/assets/4e707614-b96d-4b30-b9bb-f9e50c2b7e18)
@kaiadu 請先 pull 這個版本做相應編輯之後再推 header 上來
