### PR TITLE
[fix] 修正 API CRUD 操作, [feat] 新增種子資料與readme說明

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+.env

--- a/server/.env
+++ b/server/.env
@@ -1,2 +1,0 @@
-DATABASE_URL=postgresql://postgres:123456@localhost:5432/Codecaine
-JWT_SECRET=super-secret-codecaine

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,36 @@
+1. 請先確認已npm套件已安裝
+
+```
+npm install
+```
+
+2. 在自己電腦下載 postgreSQL 與 pgAdmin
+
+3. 在自己電腦建立一個用於測試的資料庫(例如：Codecaine)
+
+4. 在 `/server` 目錄建立 `.env` 檔
+
+5. 在 `.env` 存入以下內容
+```
+DATABASE_URL=postgresql://[你的postgre使用者名稱]:[你的密碼]@localhost:5432/[你剛創立的測試資料庫名稱]
+JWT_SECRET=[可以是任意字串，也自行製作金鑰]
+```
+
+6. 確認你的 Terminal 移動到 server 資料夾內
+
+7. 在 Terminal 依序執行下列指令
+a. 在資料庫建立資料表
+```
+npm run generate 
+npm run migrate 
+```
+b. 建立種子資料(測試用假資料)
+```
+npm run seed
+```
+
+補充：清除種子資料
+```
+npm run sneed:clean
+```
+注意：這行指令會清除資料庫內所有筆資料，若你有自行新增的測試資料也會遭到清除

--- a/server/db/schema.js
+++ b/server/db/schema.js
@@ -35,7 +35,7 @@ const pensTable = pgTable("pens", {
   css_code: text("css_code"),
   js_code: text("js_code"),
   title: varchar("title", { length: 100 }).notNull(),
-  description: text().notNull(),
+  description: text(), // 刪除 description 的 not null設定
   is_private: boolean("is_private").default(false),
   created_at: timestamp().defaultNow(),
 });
@@ -99,7 +99,7 @@ const penTagsTable = pgTable(
   "pen_tags",
   {
     pen_id: integer("pen_id")
-      .references(() => pensTable.id)
+      .references(() => pensTable.id, { onDelete: "cascade" }) 
       .notNull(),
     tag_id: integer("tag_id")
       .references(() => tagsTable.id)

--- a/server/drizzle/0003_swift_puma.sql
+++ b/server/drizzle/0003_swift_puma.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pens" ALTER COLUMN "description" DROP NOT NULL;

--- a/server/drizzle/0004_nifty_jetstream.sql
+++ b/server/drizzle/0004_nifty_jetstream.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "pen_tags" DROP CONSTRAINT "pen_tags_pen_id_pens_id_fk";
+--> statement-breakpoint
+ALTER TABLE "pen_tags" ADD CONSTRAINT "pen_tags_pen_id_pens_id_fk" FOREIGN KEY ("pen_id") REFERENCES "public"."pens"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/drizzle/meta/0003_snapshot.json
+++ b/server/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,517 @@
+{
+  "id": "45808609-7312-4dd0-b393-833ea2d99a1e",
+  "prevId": "5e781349-8394-4bc4-bc0f-f98c8738e6c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_pen_id_pens_id_fk": {
+          "name": "comments_pen_id_pens_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorites_pen_id_pens_id_fk": {
+          "name": "favorites_pen_id_pens_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_pen_id_pk": {
+          "name": "favorites_user_id_pen_id_pk",
+          "columns": [
+            "user_id",
+            "pen_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pen_tags": {
+      "name": "pen_tags",
+      "schema": "",
+      "columns": {
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pen_tags_pen_id_pens_id_fk": {
+          "name": "pen_tags_pen_id_pens_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pen_tags_tag_id_tags_id_fk": {
+          "name": "pen_tags_tag_id_tags_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pen_tags_pen_id_tag_id_pk": {
+          "name": "pen_tags_pen_id_tag_id_pk",
+          "columns": [
+            "pen_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pens": {
+      "name": "pens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_code": {
+          "name": "html_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "css_code": {
+          "name": "css_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "js_code": {
+          "name": "js_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pens_user_id_users_id_fk": {
+          "name": "pens_user_id_users_id_fk",
+          "tableFrom": "pens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pro": {
+          "name": "is_pro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link1": {
+          "name": "profile_link1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link2": {
+          "name": "profile_link2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link3": {
+          "name": "profile_link3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/0004_snapshot.json
+++ b/server/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,517 @@
+{
+  "id": "374546a0-1c14-4820-919c-bda993435624",
+  "prevId": "45808609-7312-4dd0-b393-833ea2d99a1e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_pen_id_pens_id_fk": {
+          "name": "comments_pen_id_pens_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "favorites_pen_id_pens_id_fk": {
+          "name": "favorites_pen_id_pens_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_pen_id_pk": {
+          "name": "favorites_user_id_pen_id_pk",
+          "columns": [
+            "user_id",
+            "pen_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pen_tags": {
+      "name": "pen_tags",
+      "schema": "",
+      "columns": {
+        "pen_id": {
+          "name": "pen_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pen_tags_pen_id_pens_id_fk": {
+          "name": "pen_tags_pen_id_pens_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "pens",
+          "columnsFrom": [
+            "pen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pen_tags_tag_id_tags_id_fk": {
+          "name": "pen_tags_tag_id_tags_id_fk",
+          "tableFrom": "pen_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pen_tags_pen_id_tag_id_pk": {
+          "name": "pen_tags_pen_id_tag_id_pk",
+          "columns": [
+            "pen_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pens": {
+      "name": "pens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_code": {
+          "name": "html_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "css_code": {
+          "name": "css_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "js_code": {
+          "name": "js_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pens_user_id_users_id_fk": {
+          "name": "pens_user_id_users_id_fk",
+          "tableFrom": "pens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pro": {
+          "name": "is_pro",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link1": {
+          "name": "profile_link1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link2": {
+          "name": "profile_link2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link3": {
+          "name": "profile_link3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1747586597522,
       "tag": "0002_abnormal_franklin_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1747935287968,
+      "tag": "0003_swift_puma",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1747936864240,
+      "tag": "0004_nifty_jetstream",
+      "breakpoints": true
     }
   ]
 }

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon index.js",
     "generate": "drizzle-kit generate",
-    "migrate": "drizzle-kit migrate"
+    "migrate": "drizzle-kit migrate",
+    "seed": "node scripts/seed.js",
+    "seed:clean": "node scripts/seed.js --cleanup"
   },
   "keywords": [],
   "author": "",

--- a/server/routes/favorites.js
+++ b/server/routes/favorites.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import db from "../db/index.js";
 import { favoritesTable, pensTable } from "../db/schema.js";
-import { eq, and } from "drizzle-orm";
+import { eq, and,  inArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/auth.js";
 
 const router = Router();
@@ -56,7 +56,7 @@ router.get("/:user_id", async (req, res) => {
   const pens = await db
     .select()
     .from(pensTable)
-    .where(pensTable.id.in(penIds));
+    .where(inArray(pensTable.id, penIds));
 
   res.json(pens);
 });

--- a/server/routes/pens.js
+++ b/server/routes/pens.js
@@ -112,6 +112,7 @@ router.put("/:id", async (req, res) => {
  */
 router.delete("/:id", async (req, res) => {
   const id = parseInt(req.params.id);
+
   await db.delete(pensTable).where(eq(pensTable.id, id));
   res.status(204).end();
 });

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import db from "../db/index.js";
 import { pensTable, tagsTable, penTagsTable } from "../db/schema.js";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 const router = Router();
 
@@ -38,7 +38,7 @@ router.get("/:tagName", async (req, res) => {
   const pens = await db
     .select()
     .from(pensTable)
-    .where(pensTable.id.in(penIds));
+    .where(inArray(pensTable.id, penIds));
 
   res.json(pens);
 });

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -1,0 +1,127 @@
+// 📦 種子資料產生器 seed.js
+import dotenv from "dotenv";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import {
+  usersTable,
+  pensTable,
+  favoritesTable,
+  commentsTable,
+  followsTable,
+  tagsTable,
+  penTagsTable
+} from "../db/schema.js";
+import { eq } from "drizzle-orm";
+
+dotenv.config();
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const db = drizzle(pool);
+
+// 工具：隨機取樣
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+const sampleTags = ["html", "css", "javascript", "gsap", "anime.js", "tailwind", "vue", "react"];
+const sampleUsers = [
+  { email: "lucy@example.com", username: "lucy", password_hash: "123", display_name: "Lucy" },
+  { email: "jay@example.com", username: "jay", password_hash: "123", display_name: "Jay" },
+  { email: "momo@example.com", username: "momo", password_hash: "123", display_name: "Momo" },
+];
+
+const run = async () => {
+  console.log("🌱 開始播種資料...");
+
+  // 1. 使用者
+  const users = await db.insert(usersTable).values(sampleUsers).returning();
+
+  // 2. 標籤
+  const tagRecords = await Promise.all(
+    sampleTags.map((name) =>
+      db.insert(tagsTable).values({ name }).onConflictDoNothing().returning()
+    )
+  );
+  const tags = tagRecords.flatMap((t) => t);
+
+  // 3. 作品
+  const pens = [];
+  for (let i = 0; i < 10; i++) {
+    const author = pick(users);
+    const [pen] = await db.insert(pensTable).values({
+      user_id: author.id,
+      title: `作品 ${i + 1}`,
+      html_code: `<h1>Hello ${i}</h1>`
+    }).returning();
+    pens.push(pen);
+
+    // 隨機加幾個標籤
+    const chosenTags = [...tags].sort(() => 0.5 - Math.random()).slice(0, 2);
+    for (const tag of chosenTags) {
+      await db.insert(penTagsTable).values({ pen_id: pen.id, tag_id: tag.id }).onConflictDoNothing();
+    }
+  }
+
+  // 4. 留言
+  for (const pen of pens) {
+    for (let i = 0; i < 2; i++) {
+      const user = pick(users);
+      await db.insert(commentsTable).values({
+        pen_id: pen.id,
+        user_id: user.id,
+        content: `這是 ${user.username} 留在 ${pen.title} 的留言`
+      });
+    }
+  }
+
+  // 5. 收藏
+  for (const user of users) {
+    const liked = [...pens].sort(() => 0.5 - Math.random()).slice(0, 3);
+    for (const pen of liked) {
+      await db.insert(favoritesTable).values({ user_id: user.id, pen_id: pen.id }).onConflictDoNothing();
+    }
+  }
+
+  // 6. 追蹤
+  await db.insert(followsTable).values([
+    { follower_id: users[0].id, following_id: users[1].id },
+    { follower_id: users[0].id, following_id: users[2].id },
+    { follower_id: users[1].id, following_id: users[0].id },
+  ]).onConflictDoNothing();
+
+  console.log("✅ 播種完成！");
+  process.exit();
+};
+
+if (process.argv.includes("--cleanup")) {
+  const cleanup = async () => {
+    console.log("🧹 開始清除資料...");
+    await db.delete(favoritesTable);
+    await db.delete(commentsTable);
+    await db.delete(followsTable);
+    await db.delete(penTagsTable);
+    await db.delete(pensTable);
+    await db.delete(tagsTable);
+    await db.delete(usersTable);
+    console.log("✅ 資料已清除完畢！");
+    process.exit();
+  };
+  cleanup();
+} else {
+  run().catch((err) => {
+    console.error("❌ 播種失敗：", err);
+    process.exit(1);
+  });
+}
+
+
+// 自動建立的資料：
+// 3 位使用者
+
+// 8 組常見標籤（html, css, javascript…）
+
+// 10 筆作品，每筆隨機加上 2 個標籤
+
+// 每篇作品有 2 則留言
+
+// 每個使用者收藏 3 筆作品
+
+// 使用者彼此之間有追蹤關係


### PR DESCRIPTION
close #90 
測試 `/server/routes` 的 API 並修復 CRUD 操作 (未加上middleware驗證)
加入種子資料 script 與測試資料庫建立 /server/README.md 說明建立步驟

README.me說明如下：

1. 請先確認npm套件已安裝

```
npm install
```

2. 在自己電腦下載 postgreSQL 與 pgAdmin

3. 在自己電腦建立一個用於測試的資料庫(例如：Codecaine)

4. 在 `/server` 目錄建立 `.env` 檔

5. 在 `.env` 存入以下內容
```
DATABASE_URL=postgresql://[你的postgre使用者名稱]:[你的密碼]@localhost:5432/[你剛創立的測試資料庫名稱]
JWT_SECRET=[可以是任意字串，也自行製作金鑰]
```

6. 確認你的 Terminal 移動到 server 資料夾內

7. 在 Terminal 依序執行下列指令
a. 在資料庫建立資料表
```
npm run generate 
npm run migrate 
```
b. 建立種子資料(測試用假資料)
```
npm run seed
```

補充：清除種子資料
```
npm run sneed:clean
```
注意：這行指令會清除資料庫內所有筆資料，若你有自行新增的測試資料也會遭到清除