### PR TITLE
[feat] 新增搜尋頁API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ import tagsRouter from "./src/routes/tags.js";
 import favoritesRouter from "./src/routes/favorites.js";
 import commentsRouter from "./src/routes/comments.js";
 import followsRouter from "./src/routes/follows.js";
+import searchRouter from "./src/routes/search.js"
 
 const { Pool } = pg;
 dotenv.config();
@@ -39,6 +40,7 @@ app.use("/api/tags", tagsRouter);
 app.use("/api/favorites", favoritesRouter);
 app.use("/api/comments", commentsRouter);
 app.use("/api/follows", followsRouter);
+app.use("/api/search", searchRouter);
 
 app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);

--- a/server/src/routes/search.js
+++ b/server/src/routes/search.js
@@ -1,0 +1,81 @@
+import express from "express";
+import db from "../config/db.js";
+import { sql, count, like, or, eq } from "drizzle-orm";
+import { pensTable, usersTable } from "../models/schema.js";
+
+const router = express.Router();
+
+const categoryMap = {
+  pens: pensTable,
+};
+
+/**
+ * /api/search/:category?q=xxx&page=yyy
+ */
+router.get("/:category", async (req, res) => {
+  const { category } = req.params;
+  const { q = "", rawPage = "1" } = req.query;
+  const page = parseInt(rawPage, 10);
+  const table = categoryMap[category];
+  const keyword = `%${q.toLowerCase()}%`;
+  const limit = 6;
+  const offset = (page - 1) * limit;
+
+  if (!table) return res.status(400).json({ error: "無效的分類" });
+
+  try {
+    const [countRow] = await db
+      .select({ count: count() })
+      .from(pensTable)
+      .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
+      .where(
+        or(
+          like(sql`LOWER(${pensTable.title})`, keyword),
+          like(sql`LOWER(${pensTable.description})`, keyword),
+          like(sql`LOWER(${usersTable.username})`, keyword)
+        )
+      );
+
+    const total = countRow.count;
+    const totalPages = Math.ceil(total / limit);
+
+    const results = await db
+      .select({
+        id: pensTable.id,
+        title: pensTable.title,
+        description: pensTable.description,
+        created_at: pensTable.created_at,
+        username: usersTable.username,
+      })
+      .from(table)
+      .leftJoin(usersTable, eq(pensTable.user_id, usersTable.id))
+      .where(
+        or(
+          like(sql`LOWER(${table.title})`, keyword),
+          like(sql`LOWER(${table.description})`, keyword),
+          like(sql`LOWER(${usersTable.username})`, keyword)
+        )
+      )
+      .orderBy(table.created_at)
+      .limit(limit)
+      .offset(offset);
+
+    res.json({
+      data: results,
+      total,
+      totalPages,
+      currentPage: page,
+    });
+  } catch (err) {
+    console.error("搜尋錯誤:", err);
+    res.status(500).json({ error: "搜尋失敗" });
+  }
+  //查總筆數
+  //查總頁數
+  //查當頁資料
+  //回傳當頁資料
+});
+
+export default router;
+
+// TODO: 當 :category 為 categoryMap 之外的值，當成 pens 來處理搜尋


### PR DESCRIPTION
close #112

API路由： `GET /api/search/:category`

範例 endpoint 格式：
```
/api/search/:category?q=關鍵字&page=頁碼
``` 

- :category：現在只支援 pens，未來可擴充其他表格
- q：搜尋關鍵字（搜尋 title、description、username 模糊比對，大小寫不敏感）
- page：頁碼（預設為第 1 頁）

回傳資料格式
```
{
  "data": [
    {
      "id": 1,
      "title": "作品標題",
      "description": "作品描述",
      "created_at": "2024-01-01T00:00:00.000Z",
      "username": "使用者名稱"
    },
    ...
  ],
  "total": 18,          // 總符合筆數
  "totalPages": 3,      // 總頁數（每頁 6 筆）
  "currentPage": 1      // 當前頁碼
}
```
前端 axios 請求範例
```javascript
const response = await axios.get(`/api/search/${category}`, {
      params: {
        q: <搜尋關鍵字>,
        page: <頁數>,
      },
    });
```
