### PR TITLE
[fix] Login.vue API呼叫路徑錯誤

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -97,7 +97,7 @@ import api from "../stores/api";
 async function syncUser() {
 	try {
 		const res = await api.get(
-			"/auth/me" // 原為 POST http://localhost:3000/api/addusers , 改為 GET http://localhost:3000/api/auth/me
+			"/api/auth/me" // 原為 POST http://localhost:3000/api/addusers , 改為 GET http://localhost:3000/api/auth/me
 		);
 
 		console.log("身份驗證成功：", res.data);


### PR DESCRIPTION
close #169
出問題的行數在 Login.vue 呼叫的 end point 
(X) /auth/me
(O) /api/auth/me
![image](https://github.com/user-attachments/assets/5943f647-3985-40df-9f4f-ecb47e027c65)
